### PR TITLE
Added test route

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,12 @@ def post_tweet(payload, token):
 def status():
     return "Hello, I am online!"
 
+@app.route("/test", methods=["POST"])
+def test():
+    for key, value in request.form.items():
+        print("  %s: %s" % (key, value))
+    return "Thanks!"
+
 @app.route("/")
 def demo():
     global twitter


### PR DESCRIPTION
Hey Toby,

This is an example endpoint that reads form data.  You can use this to see how data can be grabbed from Zapier.  I've modified the zapier config to hit the publicly available endpoint for your service (https://sinerider-twitter.herokuapp.com/api/zapier-replies).

Also, here is a curl that you could use when testing locally that passes in some of the fields that I think you might need:

`curl -X POST http://localhost:5000/test -H "Content-Type: application/x-www-form-urlencoded" -d "id=1234567890&in_reply_to_user_id=1234567890&text=thisistesttext&created_at=Sun%20Mar%2012%2000%3A06%3A56%20%2B0000%202023&user__id=1234567890"`