### PR TITLE
Small bugfixes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -231,7 +231,7 @@ def start_work_queue_polling():
 
 def start_refresh_token_polling():
     """ Attempts to refresh all user tokens every 5 minutes. """
-    polling.poll(twitter_client.refresh_all_tokens, step=5 * 60, poll_forever=True)
+    polling.poll(twitter_client.refresh_all_tokens, step=60, poll_forever=True)
 
 
 def start_submission_tweet_polling():

--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,8 @@ import json
 import random
 import sys
 import asyncio
+import traceback
+
 import requests
 import polling
 from flask import Flask, request, Response
@@ -165,7 +167,7 @@ async def do_scoring(work_row):
             persistence.complete_queued_work(tweet_id)
 
         score_data = json.loads(response.text)
-        persistence.add_leaderboard_entry(player_name, score_data)
+        persistence.add_leaderboard_entry(player_name, score_data, submission_url)
 
         # Mark this job as complete
         persistence.complete_queued_work(tweet_id)
@@ -197,7 +199,8 @@ async def do_scoring(work_row):
                 print(e)
 
     except Exception as e:
-        print(e)
+        traceback.print_exc()
+
         # We need to eventually give up...
         if attempts >= 3:
             notify_user_unknown_error(player_name, tweet_id)

--- a/app/persistence.py
+++ b/app/persistence.py
@@ -121,7 +121,7 @@ class Persistence:
         else:
             self.config_table.update(existing_config["id"], {"value": value})
 
-    def add_leaderboard_entry(self, playerName, scoringPayload):
+    def add_leaderboard_entry(self, playerName, scoringPayload, submission_url):
         """ Adds a leaderboard entry to the leaderboard table
         :param playerName: The name of the player
         :param scoringPayload: The payload received from the scoring service
@@ -131,7 +131,7 @@ class Persistence:
         gameplayUrl = scoringPayload["gameplay"]
         level = scoringPayload["level"]
         charCount = scoringPayload["charCount"]
-        playURL = scoringPayload["playURL"]
+        playURL = submission_url
         time = scoringPayload["time"]
         self.leaderboard_table.create(
             {"expression": expression, "time": time, "level": level, "playURL": playURL, "charCount": charCount,

--- a/app/twitter.py
+++ b/app/twitter.py
@@ -69,7 +69,11 @@ class TwitterClient:
         """ Forces all users managed by this module to refresh their authentication tokens.  This needs to happen
         periodically, and should be done no less than 2 hours. """
         for config in self.v20_creds:
-            self.__refresh(config)
+            try:
+                self.__refresh(config)
+            except Exception as e:
+                print("Failed refreshing tokens: %s" % (str(e)))
+
 
     def __find_submissions_since(self, since_id=None):
         """ Returns all submissions posted since the last (newest) tweet we've processed.  Does the work here to


### PR DESCRIPTION
1) Pass through gameplay URL instead of reading it back from scoring service (dunno why we did this in the first place).
2) Wrap token refreshes in try blocks to avoid refresh token thread death.
3) Change cadence of refresh token